### PR TITLE
Improved email validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 
 # PHPUnit
 .phpunit.result.cache
+
+# Build artifacts
+build/

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "ext-json": "*",
         "symfony/serializer": "^4.3",
         "symfony/property-access": "^4.3",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "egulias/email-validator": "^2.1"
     },
     "require-dev": {
         "symfony/var-dumper": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,125 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3486d164ba1c6324020daaa98a0494e7",
+    "content-hash": "fc77922cd133986c2d0962f90518b29a",
     "packages": [
+        {
+            "name": "doctrine/lexer",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "time": "2019-06-08T11:03:04+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "2.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "128cc721d771ec2c46ce59698f4ca42b73f71b25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/128cc721d771ec2c46ce59698f4ca42b73f71b25",
+                "reference": "128cc721d771ec2c46ce59698f4ca42b73f71b25",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.0.1",
+                "php": ">= 5.5"
+            },
+            "require-dev": {
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
+                "satooshi/php-coveralls": "^1.0.1"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2019-06-23T10:14:27+00:00"
+        },
         {
             "name": "psr/log",
             "version": "1.1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
             <directory suffix=".php">./src</directory>
             <exclude>
                 <directory>./vendor</directory>
-            </exclude>>
+            </exclude>
         </whitelist>
     </filter>
     <logging>

--- a/tests/EmailParserTest.php
+++ b/tests/EmailParserTest.php
@@ -59,10 +59,11 @@ class EmailParserTest extends TestCase
         $emails = $parser->parseEmails([
             'omegavesko@gmail.com',
             'test@test.dev',
-            'asopdkasopkd@ekfewfeef'
+            'asopdkasopkd@ekfewfeef',
+            'asdasdasdasdasd'
         ]);
 
-        $this->assertCount(2, $emails);
+        $this->assertCount(3, $emails);
         $this->assertContainsOnlyInstancesOf(EmailInformation::class, $emails);
     }
 }


### PR DESCRIPTION
This pull request improves email validation by using `egulias/email-validator` as the mechanism for email validation, rather than relying on PHP's primitive `FILTER_VALIDATE_EMAIL`. The validation used is left as a configurable option to the user, though if none is provided, a simple `RFCValidation` will be used as a sane default value.